### PR TITLE
Adding changes to use any capability which starts with 'browserstack.'

### DIFF
--- a/serenity.properties
+++ b/serenity.properties
@@ -12,8 +12,12 @@ browserstack.user=BROWSERSTACK_USERNAME
 browserstack.key=BROWSERSTACK_ACCESS_KEY
 browserstack.server=hub-cloud.browserstack.com
 
-browserstack.build=serenity-browserstack
-browserstack.debug=true
+bstack_build=serenity-browserstack
+bstack_debug=true
+
+#You can add any capability with a prefix 'bstack_' as below
+#For example to use browserstack.console as verbose use below capability
+bstack_browserstack.console=verbose
 
 
 environment.single.name=single_test

--- a/src/test/java/com/browserstack/BrowserStackSerenityDriver.java
+++ b/src/test/java/com/browserstack/BrowserStackSerenityDriver.java
@@ -39,9 +39,9 @@ public class BrowserStackSerenityDriver implements DriverSource {
             if(key.equals("browserstack.user") || key.equals("browserstack.key") || key.equals("browserstack.server")){
                 continue;
             }
-            else if(key.startsWith("browserstack.")){
-                capabilities.setCapability(key.replace("browserstack.", ""), environmentVariables.getProperty(key));
-                if(key.equals("browserstack.local")){
+            else if(key.startsWith("bstack_")){
+                capabilities.setCapability(key.replace("bstack_", ""), environmentVariables.getProperty(key));
+                if(key.equals("bstack_browserstack.local")){
                     System.setProperty("browserstack.local", "true");
                 }
             }

--- a/src/test/java/com/browserstack/BrowserStackSerenityTest.java
+++ b/src/test/java/com/browserstack/BrowserStackSerenityTest.java
@@ -24,7 +24,7 @@ public class BrowserStackSerenityTest {
         }
 
         String environment = System.getProperty("environment");
-        String key = "browserstack.local";
+        String key = "bstack_browserstack.local";
         boolean is_local = environmentVariables.getProperty(key) != null && environmentVariables.getProperty(key).equals("true");
 
         if(environment != null && !is_local){


### PR DESCRIPTION
Earlier, any key in serenity properties file which starts with 'browserstack.' used to be parsed and gets replaced with null. This was barrier if user wants to use the capability which starts with 'browserstack.' for example 'browserstack.video'. Then in the earlier case, after parsing, only 'video' used to go as capability which will not serve the purpose. Added the required changes and tested them.