### PR TITLE
fix: remove surefire-junit47 dependency resulting in non-zero exit code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
             <groupId>com.browserstack</groupId>
             <artifactId>browserstack-java-sdk</artifactId>
             <version>LATEST</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,14 @@
         <repository>
             <id>serenity</id>
             <name>bintray</name>
-            <url>http://dl.bintray.com/serenity/maven</url>
+            <url>https://dl.bintray.com/serenity/maven</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>serenity</id>
             <name>bintray-plugins</name>
-            <url>http://dl.bintray.com/serenity/maven</url>
+            <url>https://dl.bintray.com/serenity/maven</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -112,9 +112,8 @@
         <dependency>
             <groupId>com.browserstack</groupId>
             <artifactId>browserstack-java-sdk</artifactId>
-            <version>1.11.2</version>
-            <scope>system</scope>
-            <systemPath>/Users/kamalpreet/Documents/browserstack/browserstack-javaagent/target/browserstack-java-sdk-1.12.7.jar</systemPath>
+            <version>LATEST</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,9 @@
         <dependency>
             <groupId>com.browserstack</groupId>
             <artifactId>browserstack-java-sdk</artifactId>
-            <version>LATEST</version>
+            <version>1.11.2</version>
+            <scope>system</scope>
+            <systemPath>/Users/kamalpreet/Documents/browserstack/browserstack-javaagent/target/browserstack-java-sdk-1.12.7.jar</systemPath>
         </dependency>
     </dependencies>
 
@@ -142,13 +144,6 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${maven.failsafe-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>${maven.failsafe-plugin.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <includes>
                         <include>com/browserstack/cucumber/SampleTest.java</include>


### PR DESCRIPTION
Remove surefire-junit47 dependency resulting in non-zero exit code